### PR TITLE
Relates to issue #2: prompt.py citations use {}, not []

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,7 +115,7 @@ async def main(volume_number, manga, text_only=False):
         )
         return start_idx, response
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         futures = []
         for i in range(0, len(volume), batch_size):
             pages = volume[i : i + batch_size]
@@ -144,8 +144,8 @@ async def main(volume_number, manga, text_only=False):
     print("Profile pages:", profile_pages)
     print("Chapter pages:", chapter_pages)
 
-    chapter_pages = [1]
-    profile_pages = [0]
+    #chapter_pages = [1]
+    #profile_pages = [0]
     print(f"{len(volume)}")
     print("\n__________\n")
     print("Saving important pages to disk for QA...")

--- a/citation_processing.py
+++ b/citation_processing.py
@@ -11,7 +11,7 @@ def clean_and_relocate_citations_sequence(text):
     )
 
     # Define a pattern to match sequences of citations that come before a period
-    pattern = re.compile(r"((?:\[\^\d+\])+)(\.)")
+    pattern = re.compile(r"((?:\[\^\{\d+\}\])+)(\.)")
     # Relocate the entire sequence of citations to after the period
     relocated_text = re.sub(pattern, r"\2\1", cleaned_text)
 
@@ -21,7 +21,7 @@ def clean_and_relocate_citations_sequence(text):
 def extract_text_and_citations(text, images, images_unscaled):
     text = clean_and_relocate_citations_sequence(text)
     # Split text by citations, capturing the citations as well
-    parts = re.split(r"(\[\^[\d\]]+\])", text)
+    parts = re.split(r"(\[\^\{\d+\}\])", text)
 
     # Initialize variables to store the current text block and its citations
     current_text = ""
@@ -29,7 +29,7 @@ def extract_text_and_citations(text, images, images_unscaled):
     output = []
 
     for part in parts:
-        if re.match(r"\[\^[\d\]]+\]", part):
+        if re.match(r"\[\^\{\d+\}\]", part):
             current_citations = [int(num) for num in re.findall(r"\d+", part)]
             valid_citations = [num for num in current_citations if num < len(images)]
             citations.extend(valid_citations)


### PR DESCRIPTION
# Pull Request

## Description

The BASSIC_PROMPT all use {} when using citations. The citation file was using [] regex

## Issue

[Issue #6: ](https://github.com/pashpashpash/manga-reader/issues/6)

## Changes Made

changed regex in citations file

## Testing

Clean install

## Screenshots (if applicable)

Attach any relevant screenshots to visually demonstrate the changes.

## Checklist

- [  * ] I have read and followed the project's contributing guidelines.
- [  * ] My code follows the project's coding style and conventions.
- [  * ] I have tested my changes and verified that existing tests pass.
- [  * ] I have documented any necessary code or configuration changes.
- [  * ] My branch is up-to-date with the latest changes from the main repository.
